### PR TITLE
feat: add ability to make assertion of arguments for multiple calls

### DIFF
--- a/lib/mocha-mock.spec.js
+++ b/lib/mocha-mock.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect')
 const {it, mock} = require('./')
 
 let mocked
-describe.only('mocha-mock', () => {
+describe('mocha-mock', () => {
   it('wraps around mochas it', () => {
     expect(true).toBe(true)
   })

--- a/lib/mock-object/mock-object.js
+++ b/lib/mock-object/mock-object.js
@@ -6,6 +6,7 @@ class MockObject {
     this.stats = {}
     this.expectations = []
     this.currentMethod = null
+    this.methodCallsCounter = {}
 
     const constructor = object.constructor
     let keys = Object.getOwnPropertyNames(object)
@@ -24,6 +25,8 @@ class MockObject {
   }
 
   shouldReceive (method) {
+    const count = this.methodCallsCounter[method] || 0
+    this.methodCallsCounter[method] = count + 1
     this.currentMethod = method
     this._expectMethodIsCalled(method)
     return this
@@ -64,13 +67,27 @@ class MockObject {
 
   with (...args) {
     const method = this.currentMethod
+    const count = this.methodCallsCounter[method]
+
     const expectation = {
       failMessage: () => {
-        const calledArgs = this.stats[method].args
-        return `Expected ${method} to be called with ${args}. Got ${JSON.stringify(calledArgs)}`
+        const calledArgs = this.stats[method].calls[count]
+
+        // TODO: improve this... doesn't really make
+        // sense to have two different fail messages
+        if (calledArgs) {
+          return `Expected ${method} to be called with ${args}. Got ${JSON.stringify(calledArgs)}`
+        } else {
+          return `Expected ${method} to be called with ${args}. Method was not called.`
+        }
       },
       execute: () => {
-        const calledArgs = this.stats[method].args
+        const calledArgs = this.stats[method].calls[count]
+        // no arguments means the method was not called
+        if (!calledArgs) {
+          return false
+        }
+
         const sameNumberOfArgs = calledArgs.length === args.length
         const matchingArgs = calledArgs.every((arg, index) => {
           return arg === args[index] || equal(arg, args[index])
@@ -97,7 +114,8 @@ class MockObject {
 
   _initializeStats (method) {
     this.stats[method] = {
-      callCount: 0
+      callCount: 0,
+      calls: []
     }
   }
 
@@ -113,8 +131,9 @@ class MockObject {
 
   _mockMethod (method) {
     this[method] = (...args) => {
-      this.stats[method].args = args
-      this.stats[method].callCount = this.stats[method].callCount + 1
+      const callCount = this.stats[method].callCount + 1
+      this.stats[method].callCount = callCount
+      this.stats[method].calls[callCount] = args
     }
   }
 }

--- a/lib/mock-object/mock-object.spec.js
+++ b/lib/mock-object/mock-object.spec.js
@@ -80,4 +80,21 @@ describe('mock-object', () => {
 
     expect(mockObject.verify()).toBe(true)
   })
+
+  it('can mock multiple function calls with different arguments', () => {
+    const callOneArgs = 'foo'
+    const callTwoArgs = 'bar'
+
+    const mockObject = new MockObject({method: () => {}})
+    mockObject
+      .shouldReceive('method')
+      .with(callOneArgs)
+      .shouldReceive('method')
+      .with(callTwoArgs)
+
+    mockObject.method(callOneArgs)
+    mockObject.method(callTwoArgs)
+
+    expect(mockObject.verify()).toBe(true)
+  })
 })


### PR DESCRIPTION
ex.

```
mock(AThing)
  .shouldReceive('method')
  .with('foo')
  .shouldReceive('method')
  .with('bar')

The first execution should be called with `'foo'`
and the second execution should be called with `'bar'`